### PR TITLE
feat(security): mitigate replay attacks with timestamp + nonce

### DIFF
--- a/src/__tests__/flow.unit.test.ts
+++ b/src/__tests__/flow.unit.test.ts
@@ -53,6 +53,39 @@ describe('Flow SDK (unit)', () => {
     expect(formData.s).toBeDefined();
     expect(formData.commerceOrder).toBe('1');
     expect(formData.apiKey).toBe('key');
+    expect(formData.timestamp).toMatch(/^\d+$/);
+    expect(formData.nonce).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('genera nonce distinto en cada firma para mitigar replay', () => {
+    const formDataA = generateFormData(
+      { commerceOrder: '1', apiKey: 'key' },
+      'secret',
+    );
+    const formDataB = generateFormData(
+      { commerceOrder: '1', apiKey: 'key' },
+      'secret',
+    );
+
+    expect(formDataA.nonce).not.toBe(formDataB.nonce);
+    expect(formDataA.s).not.toBe(formDataB.s);
+  });
+
+  it('serializa optional como JSON string para la firma', () => {
+    const formData = generateFormData(
+      {
+        commerceOrder: '1',
+        optional: { orderId: 'abc' },
+        amount: 1000,
+        apiKey: 'key',
+      },
+      'secret',
+    );
+
+    expect(formData.optional).toBe('{"orderId":"abc"}');
+    expect(formData.amount).toBe('1000');
   });
 
   it('valida y normaliza fechas para consultas por día', () => {

--- a/src/utils/flow.utils.ts
+++ b/src/utils/flow.utils.ts
@@ -2,6 +2,7 @@ import flowConstants from '../constants/flow.constants';
 import { FlowPaymentMethods, FlowPaymentStatus } from '../types/flow';
 import { parse, isValid, format } from 'date-fns';
 import CryptoJS from 'crypto-js';
+import { randomUUID } from 'crypto';
 
 /**
  * Obtiene el código de metodo de pago en Flow.
@@ -47,6 +48,31 @@ function isValidPaymentReceivedByDate(
 }
 
 /**
+ * Normaliza parámetros de request a strings para firmar y enviar a Flow.
+ * Flow firma concatenando key+value; objetos deben serializarse (p. ej. optional).
+ */
+function serializeFlowParams(
+  data: Record<string, unknown>,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (key === 'optional' && typeof value === 'object') {
+      normalized[key] = JSON.stringify(value);
+      continue;
+    }
+
+    normalized[key] = String(value);
+  }
+
+  return normalized;
+}
+
+/**
  * Genera una firma HMAC-SHA256 para asegurar la autenticidad de los datos enviados a Flow.
  * @param params Parámetros a firmar.
  * @returns Firma generada.
@@ -69,15 +95,22 @@ function generateSignature(
  * @param secretKey Recibe la clave secreta para firmar los datos
  * @returns Retorna un objeto con los datos y la firma
  */
-function generateFormData<T extends Record<string, string>>(
+function generateFormData<T extends Record<string, unknown>>(
   data: T,
   secretKey: string,
-) {
-  const signature = generateSignature(data, secretKey); // Generar firma
+): Record<string, string> & { s: string } {
+  const antiReplayData = {
+    ...data,
+    timestamp: data.timestamp ?? Math.floor(Date.now() / 1000),
+    nonce: data.nonce ?? randomUUID(),
+  };
+
+  const normalized = serializeFlowParams(antiReplayData);
+  const signature = generateSignature(normalized, secretKey);
 
   return {
-    ...data,
-    s: signature, // Agregar firma a los datos enviados
+    ...normalized,
+    s: signature,
   };
 }
 
@@ -87,4 +120,5 @@ export {
   isValidPaymentReceivedByDate,
   generateSignature,
   generateFormData,
+  serializeFlowParams,
 };


### PR DESCRIPTION
## Summary
- add anti-replay metadata to signed payloads in `generateFormData`
- include `timestamp` (Unix epoch seconds) and `nonce` (UUID v4) before signature generation
- keep deterministic signature behavior for the same explicit input by preserving provided fields
- extend unit tests to validate new fields and nonce/signature variation across calls

## Security impact
Previously, a captured valid signed request could be replayed indefinitely. This change makes each signed request unique and time-bound from the client payload perspective.

## Files changed
- `src/utils/flow.utils.ts`
- `src/__tests__/flow.unit.test.ts`

## Validation
- unit tests passing for updated signing behavior
- TypeScript build passing

## Backend follow-up required
To fully enforce replay protection, backend should reject:
- requests older than 5 minutes
- reused nonces within the allowed time window
