### PR TITLE
[codex] Add sanitized Flow API error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,25 @@ const flow = new Flow(
 );
 ```
 
+### Logging de errores
+
+Por defecto el SDK no escribe errores de Flow en consola. Si necesitas logging,
+actívalo explícitamente; los eventos emitidos no incluyen el payload HTTP crudo.
+
+```typescript
+const flow = new Flow('tu_api_key', 'tu_secret_key', 'sandbox', {
+  logging: true,
+});
+
+const flowWithLogger = new Flow('tu_api_key', 'tu_secret_key', 'sandbox', {
+  logger: {
+    error(event) {
+      // Enviar a tu logger/APM. Evento sanitizado: endpoint, method, statusCode, message, flowCode.
+    },
+  },
+});
+```
+
 ## Funcionalidades principales
 
 ### 1. Pagos

--- a/src/__tests__/flow.unit.test.ts
+++ b/src/__tests__/flow.unit.test.ts
@@ -144,4 +144,65 @@ describe('Flow SDK (unit)', () => {
 
     expect(logger.error).not.toHaveBeenCalled();
   });
+
+  it('mantiene FlowAPIError aunque el logger falle', () => {
+    const logger = {
+      error: jest.fn(() => {
+        throw new Error('logger unavailable');
+      }),
+    };
+
+    const error = createFlowAPIError({
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      endpoint: '/create',
+      method: 'post',
+      body: { code: 101, message: 'Solicitud inválida' },
+      options: { logger },
+    });
+
+    expect(error.flowCode).toBe(101);
+    expect(error.flowMessage).toBe('Solicitud inválida');
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('emite console.error sanitizado cuando logging es true', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    createFlowAPIError({
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      endpoint: '/create',
+      method: 'post',
+      body: {
+        code: 101,
+        message: 'Solicitud inválida',
+        token: 'secret-token',
+        rut: '11111111-1',
+        amount: 1000,
+      },
+      options: { logging: true },
+    });
+
+    expect(consoleError).toHaveBeenCalledWith('[flowcl-pagos]', {
+      type: 'flow_api_error',
+      endpoint: '/create',
+      method: 'post',
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      flowCode: 101,
+    });
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        token: expect.any(String),
+        rut: expect.any(String),
+        amount: expect.any(Number),
+      }),
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/src/__tests__/flow.unit.test.ts
+++ b/src/__tests__/flow.unit.test.ts
@@ -1,7 +1,7 @@
 import Flow from '../clients/flow';
 import FlowMerchants from '../clients/flow.merchants';
 import FlowPayments from '../clients/flow.payments';
-import { FlowAuthenticationError } from '../errors';
+import { FlowAuthenticationError, createFlowAPIError } from '../errors';
 import {
   generateFormData,
   generateSignature,
@@ -91,5 +91,57 @@ describe('Flow SDK (unit)', () => {
   it('valida y normaliza fechas para consultas por día', () => {
     expect(isValidPaymentReceivedByDate('2026-06-02')).toBe('2026-06-02');
     expect(isValidPaymentReceivedByDate('invalid')).toBeNull();
+  });
+
+  it('emite logs sanitizados sin payload crudo de Flow', () => {
+    const logger = { error: jest.fn() };
+
+    const error = createFlowAPIError({
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      endpoint: '/create',
+      method: 'post',
+      body: {
+        code: 101,
+        message: 'Solicitud inválida',
+        token: 'secret-token',
+        rut: '11111111-1',
+        amount: 1000,
+      },
+      options: { logging: true, logger },
+    });
+
+    expect(error.flowCode).toBe(101);
+    expect(error.flowMessage).toBe('Solicitud inválida');
+    expect(logger.error).toHaveBeenCalledWith({
+      type: 'flow_api_error',
+      endpoint: '/create',
+      method: 'post',
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      flowCode: 101,
+    });
+    expect(logger.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        token: expect.any(String),
+        rut: expect.any(String),
+        amount: expect.any(Number),
+      }),
+    );
+  });
+
+  it('no emite logs cuando logging es false', () => {
+    const logger = { error: jest.fn() };
+
+    createFlowAPIError({
+      statusCode: 400,
+      message: 'Request failed with status code 400',
+      endpoint: '/create',
+      method: 'post',
+      body: { code: 101, message: 'Solicitud inválida' },
+      options: { logging: false, logger },
+    });
+
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/src/clients/flow.coupons.ts
+++ b/src/clients/flow.coupons.ts
@@ -1,11 +1,12 @@
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCreateDiscountCouponError,
   FlowDeleteDiscountCouponError,
   FlowEditDiscountCouponError,
   FlowGetDiscountCouponError,
   FlowListDiscountCouponsError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import axios, { AxiosInstance } from 'axios';
 import { generateFormData } from '../utils/flow.utils';
@@ -29,6 +30,7 @@ export default class FlowCoupons {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   /**
    * Este servicio permite crear un cupón de descuento
    * @param {FlowCreateDiscountCouponRequest} data Datos para crear el cupón de descuento
@@ -91,13 +93,19 @@ export default class FlowCoupons {
    * @param baseURL URL base de la API de Flow.
    * @throws FlowAuthenticationError Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -144,8 +152,14 @@ export default class FlowCoupons {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.error(JSON.stringify(err.response?.data, null, 2));
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.customers.ts
+++ b/src/clients/flow.customers.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowChargeCardError,
   FlowCreateCustomerError,
@@ -18,6 +17,8 @@ import {
   FlowReverseChargeCardError,
   FlowSendChargeCardError,
   FlowSendMassiveChargeCardError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import {
   FlowGetCustomerListResponse,
@@ -60,6 +61,7 @@ export default class FlowCustomers {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   /**
    * Operaciones relacionadas con clientes
    */
@@ -210,13 +212,19 @@ export default class FlowCustomers {
    * @param baseURL URL base de la API de Flow.
    * @throws FlowAuthenticationError Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
       baseURL: `${baseURL}/customer`,
@@ -261,8 +269,14 @@ export default class FlowCustomers {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.log(err.response?.data);
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.invoices.ts
+++ b/src/clients/flow.invoices.ts
@@ -1,13 +1,14 @@
 import axios, { AxiosInstance } from 'axios';
 import qs from 'qs';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCancelInvoicePendingPaymentError,
   FlowGetInvoiceDataError,
   FlowGetOverdueInvoicesError,
   FlowRecordExternalPaymentAndMarkInvoicePaidError,
   FlowRetryOverdueInvoicePaymentError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import {
   generateFormData,
@@ -29,6 +30,7 @@ export default class FlowInvoices {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   public get = {
     /**
      * Este servicio permite obtener los datos de un Importe.
@@ -87,13 +89,19 @@ export default class FlowInvoices {
    * @param  {string}baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -139,8 +147,14 @@ export default class FlowInvoices {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.log(err.response?.data);
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.merchants.ts
+++ b/src/clients/flow.merchants.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosInstance } from 'axios';
 import { generateFormData } from '../utils/flow.utils';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCreateAssociatedMerchantError,
   FlowDeleteAssociatedMerchantError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import qs from 'qs';
 import {
@@ -25,6 +26,7 @@ export default class FlowMerchants {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
 
   public createAssociatedMerchant: (
     data: FlowCreateAssociatedMerchantRequest,
@@ -81,13 +83,19 @@ export default class FlowMerchants {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -133,8 +141,14 @@ export default class FlowMerchants {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.error(err.response?.data);
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.payments.ts
+++ b/src/clients/flow.payments.ts
@@ -13,7 +13,6 @@ import {
 } from '../types/flow.payments';
 
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCreatePaymentByEmailError,
   FlowCreatePaymentError,
@@ -21,6 +20,8 @@ import {
   FlowPaymentsReceivedByDateError,
   FlowStatusExtendedError,
   FlowTransactionsReceivedByDateError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import {
   generateFormData,
@@ -40,6 +41,7 @@ export default class FlowPayments {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
 
   /**
    * Objeto que proporciona métodos para interactuar con los pagos en Flow.
@@ -133,13 +135,19 @@ export default class FlowPayments {
    * @param  {string}baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -191,14 +199,14 @@ export default class FlowPayments {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        const flowBody = err.response?.data as
-          | { code?: number; message?: string }
-          | undefined;
-        throw new FlowAPIError(
-          err.response?.status || 500,
-          err.message,
-          flowBody,
-        );
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.plans.ts
+++ b/src/clients/flow.plans.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCreatePlanError,
   FlowEditPlanError,
   FlowListPlansError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import { generateFormData } from '../utils/flow.utils';
 import {
@@ -28,6 +29,7 @@ export default class FlowPlans {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
 
   /**
    * Este servicio permite crear un nuevo Plan de Suscripción
@@ -85,13 +87,19 @@ export default class FlowPlans {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -142,8 +150,14 @@ export default class FlowPlans {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.error(JSON.stringify(err.response?.data, null, 2));
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.refunds.ts
+++ b/src/clients/flow.refunds.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCancelRefundError,
+  FlowClientOptions,
   FlowCreateRefundError,
   FlowRefundStatusError,
+  createFlowAPIError,
 } from '../errors';
 import {
   FlowCancelRefundResponse,
@@ -22,6 +23,7 @@ export default class FlowRefunds {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
 
   /**
    * Objeto que proporciona métodos para interactuar con los reembolsos en Flow.
@@ -63,13 +65,19 @@ export default class FlowRefunds {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -120,7 +128,14 @@ export default class FlowRefunds {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.settlement.ts
+++ b/src/clients/flow.settlement.ts
@@ -1,8 +1,9 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
+  FlowClientOptions,
   FlowGetLiquidationsByDateRangeError,
+  createFlowAPIError,
 } from '../errors';
 import { generateFormData } from '../utils/flow.utils';
 import qs from 'qs';
@@ -18,6 +19,7 @@ export default class FlowSettlements {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   /**
    * Este método se utiliza para obtener el(los) encabezado(s) de liquidación(es) dentro del rango de fechas ingresado (permite filtrar también por la moneda). Para obtener la liquidación completa (encabezado y detalles) utilizar el servicio /settlement/getByIdv2
    * @param {FlowGetSettlementHeadersByDateRangeRequest} data Datos de la petición.
@@ -47,13 +49,19 @@ export default class FlowSettlements {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -99,7 +107,14 @@ export default class FlowSettlements {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.subscriptions.ts
+++ b/src/clients/flow.subscriptions.ts
@@ -4,7 +4,6 @@ import qs from 'qs';
 import {
   FlowAddDiscountToSubscriptionError,
   FlowAddItemToSubscriptionError,
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCancelScheduledPlanChangeError,
   FlowCancelSubscriptionError,
@@ -16,6 +15,8 @@ import {
   FlowRemoveDiscountFromSubscriptionError,
   FlowRemoveItemFromSubscriptionError,
   FlowUpdateSubscriptionTrialDaysError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import {
   FlowAddDiscountToSubscriptionResponse,
@@ -44,6 +45,7 @@ export default class FlowSubscriptions {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   /**
    * Este servicio permite crear una nueva suscripción de un cliente a un Plan. Para crear una nueva suscripción, basta con enviar los parámetros planId y customerId
    * @param {FlowCreateSubscriptionToPlanRequest} data Datos para crear la suscripción.
@@ -211,13 +213,19 @@ export default class FlowSubscriptions {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -263,8 +271,14 @@ export default class FlowSubscriptions {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.error(JSON.stringify(err.response?.data, null, 2));
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.subscriptionsItems.ts
+++ b/src/clients/flow.subscriptionsItems.ts
@@ -1,12 +1,13 @@
 import axios, { AxiosInstance } from 'axios';
 import {
-  FlowAPIError,
   FlowAuthenticationError,
   FlowCreateAdditionalSubscriptionItemError,
   FlowDeleteAdditionalSubscriptionItemError,
   FlowEditAdditionalSubscriptionItemError,
   FlowGetAdditionalSubscriptionItemError,
   FlowListAdditionalSubscriptionItemError,
+  FlowClientOptions,
+  createFlowAPIError,
 } from '../errors';
 import { generateFormData } from '../utils/flow.utils';
 import {
@@ -27,6 +28,7 @@ export default class FlowSubscriptionsItems {
   private apiKey: string;
   private secretKey: string;
   private axiosInstance: AxiosInstance;
+  private options?: FlowClientOptions;
   /**
    * Este servicio permite obtener los datos de un item adicional de suscripción
    * @param {string} itemId ID del item adicional de suscripción.
@@ -94,13 +96,19 @@ export default class FlowSubscriptionsItems {
    * @param {string} baseURL URL base de la API de Flow.
    * @throws {FlowAuthenticationError} Si no se proporciona apiKey o secretKey.
    */
-  constructor(apiKey: string, secretKey: string, baseURL: string) {
+  constructor(
+    apiKey: string,
+    secretKey: string,
+    baseURL: string,
+    options?: FlowClientOptions,
+  ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
     }
 
     this.apiKey = apiKey;
     this.secretKey = secretKey;
+    this.options = options;
 
     // Crear una instancia de Axios con la configuración base
     this.axiosInstance = axios.create({
@@ -146,8 +154,14 @@ export default class FlowSubscriptionsItems {
       return response.data;
     } catch (err) {
       if (axios.isAxiosError(err)) {
-        console.error(JSON.stringify(err.response?.data, null, 2));
-        throw new FlowAPIError(err.response?.status || 500, err.message);
+        throw createFlowAPIError({
+          statusCode: err.response?.status || 500,
+          message: err.message,
+          body: err.response?.data,
+          endpoint,
+          method,
+          options: this.options,
+        });
       }
       error(err);
     }

--- a/src/clients/flow.ts
+++ b/src/clients/flow.ts
@@ -1,4 +1,4 @@
-import { FlowAuthenticationError } from '../errors';
+import { FlowAuthenticationError, FlowClientOptions } from '../errors';
 import FlowCoupons from './flow.coupons';
 import FlowCustomers from './flow.customers';
 import FlowInvoices from './flow.invoices';
@@ -61,12 +61,14 @@ class Flow {
    * @param apiKey Clave de API proporcionada por Flow.
    * @param secretKey Clave secreta proporcionada por Flow.
    * @param enviroment Entorno de Flow ('sandbox' o 'production').
+   * @param options Opciones del cliente, incluyendo logging sanitizado.
    * @throws FlowAuthenticationError Si no se proporciona apiKey o secretKey.
    */
   constructor(
     apiKey: string,
     secretKey: string,
     enviroment: 'sandbox' | 'production' = 'sandbox',
+    options?: FlowClientOptions,
   ) {
     if (!apiKey || !secretKey) {
       throw new FlowAuthenticationError();
@@ -77,20 +79,26 @@ class Flow {
         ? 'https://sandbox.flow.cl/api'
         : 'https://www.flow.cl/api';
 
-    this.payments = new FlowPayments(apiKey, secretKey, baseURL);
-    this.refunds = new FlowRefunds(apiKey, secretKey, baseURL);
-    this.customers = new FlowCustomers(apiKey, secretKey, baseURL);
-    this.plans = new FlowPlans(apiKey, secretKey, baseURL);
-    this.subscriptions = new FlowSubscriptions(apiKey, secretKey, baseURL);
+    this.payments = new FlowPayments(apiKey, secretKey, baseURL, options);
+    this.refunds = new FlowRefunds(apiKey, secretKey, baseURL, options);
+    this.customers = new FlowCustomers(apiKey, secretKey, baseURL, options);
+    this.plans = new FlowPlans(apiKey, secretKey, baseURL, options);
+    this.subscriptions = new FlowSubscriptions(
+      apiKey,
+      secretKey,
+      baseURL,
+      options,
+    );
     this.subscriptionsItems = new FlowSubscriptionsItems(
       apiKey,
       secretKey,
       baseURL,
+      options,
     );
-    this.coupons = new FlowCoupons(apiKey, secretKey, baseURL);
-    this.invoices = new FlowInvoices(apiKey, secretKey, baseURL);
-    this.settlements = new FlowSettlements(apiKey, secretKey, baseURL);
-    this.merchants = new FlowMerchants(apiKey, secretKey, baseURL);
+    this.coupons = new FlowCoupons(apiKey, secretKey, baseURL, options);
+    this.invoices = new FlowInvoices(apiKey, secretKey, baseURL, options);
+    this.settlements = new FlowSettlements(apiKey, secretKey, baseURL, options);
+    this.merchants = new FlowMerchants(apiKey, secretKey, baseURL, options);
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -86,6 +86,14 @@ export type FlowClientOptions = {
   logger?: FlowLogger;
 };
 
+function emitFlowAPIErrorLog(emit: () => void): void {
+  try {
+    emit();
+  } catch {
+    // Logging must never mask the original FlowAPIError.
+  }
+}
+
 export function getFlowErrorBody(
   data: unknown,
 ): { code?: number; message?: string } | undefined {
@@ -124,23 +132,27 @@ export function createFlowAPIError({
   }
 
   if (options?.logger) {
-    options.logger.error({
-      type: 'flow_api_error',
-      endpoint,
-      method,
-      statusCode,
-      message,
-      flowCode: flowBody?.code,
+    emitFlowAPIErrorLog(() => {
+      options.logger?.error({
+        type: 'flow_api_error',
+        endpoint,
+        method,
+        statusCode,
+        message,
+        flowCode: flowBody?.code,
+      });
     });
   } else if (options?.logging) {
     const logger = globalThis.console;
-    logger.error('[flowcl-pagos]', {
-      type: 'flow_api_error',
-      endpoint,
-      method,
-      statusCode,
-      message,
-      flowCode: flowBody?.code,
+    emitFlowAPIErrorLog(() => {
+      logger.error('[flowcl-pagos]', {
+        type: 'flow_api_error',
+        endpoint,
+        method,
+        statusCode,
+        message,
+        flowCode: flowBody?.code,
+      });
     });
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -66,6 +66,87 @@ export class FlowAPIError extends FlowError {
   }
 }
 
+export type FlowRequestMethod = 'post' | 'get';
+
+export type FlowAPIErrorLogEvent = {
+  type: 'flow_api_error';
+  endpoint: string;
+  method: FlowRequestMethod;
+  statusCode: number;
+  message: string;
+  flowCode?: number;
+};
+
+export type FlowLogger = {
+  error: (event: FlowAPIErrorLogEvent) => void;
+};
+
+export type FlowClientOptions = {
+  logging?: boolean;
+  logger?: FlowLogger;
+};
+
+export function getFlowErrorBody(
+  data: unknown,
+): { code?: number; message?: string } | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined;
+  }
+
+  const body = data as { code?: unknown; message?: unknown };
+
+  return {
+    code: typeof body.code === 'number' ? body.code : undefined,
+    message: typeof body.message === 'string' ? body.message : undefined,
+  };
+}
+
+export function createFlowAPIError({
+  statusCode,
+  message,
+  body,
+  endpoint,
+  method,
+  options,
+}: {
+  statusCode: number;
+  message: string;
+  body: unknown;
+  endpoint: string;
+  method: FlowRequestMethod;
+  options?: FlowClientOptions;
+}): FlowAPIError {
+  const flowBody = getFlowErrorBody(body);
+  const error = new FlowAPIError(statusCode, message, flowBody);
+
+  if (options?.logging === false) {
+    return error;
+  }
+
+  if (options?.logger) {
+    options.logger.error({
+      type: 'flow_api_error',
+      endpoint,
+      method,
+      statusCode,
+      message,
+      flowCode: flowBody?.code,
+    });
+  } else if (options?.logging) {
+    const logger = globalThis.console;
+    logger.error('[flowcl-pagos]', {
+      type: 'flow_api_error',
+      endpoint,
+      method,
+      statusCode,
+      message,
+      flowCode: flowBody?.code,
+    });
+  }
+
+  return error;
+}
+
 /**
  * Error cuando hay problemas al obtener los pagos recibidos por fecha.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 // src/index.ts
 export { default as Flow } from './clients/flow';
+export type {
+  FlowAPIErrorLogEvent,
+  FlowClientOptions,
+  FlowLogger,
+} from './errors';


### PR DESCRIPTION
## What changed

- Adds optional Flow client logging through `FlowClientOptions`.
- Supports `logging: true`, `logging: false`, and a custom `logger.error(event)` sink.
- Centralizes Flow API error creation so emitted log events are sanitized.
- Propagates client options across all Flow resource clients.
- Exports logger-related types and documents usage in the README.
- Adds unit coverage for sanitized log events and explicit log disabling.

## Why

Flow API error responses may contain sensitive payment or customer data. The SDK should not print raw HTTP response bodies to console or APM logs. This keeps logging opt-in and limits events to non-sensitive fields: `type`, `endpoint`, `method`, `statusCode`, `message`, and `flowCode`.

## Validation

- `npm run build`
- `npm run test:unit`
- `npm run lint` (passes with existing test `console` warnings)
- `rg "console\\.(log|error)" src/clients` returns no matches