### PR TITLE
[codex] Add Flow webhook verification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,30 @@ const flowWithLogger = new Flow('tu_api_key', 'tu_secret_key', 'sandbox', {
 });
 ```
 
+### Verificar callbacks de Flow
+
+Flow notifica `urlConfirmation` con un `token` por POST. No proceses el
+callback solo porque recibiste ese token: verifica el estado contra Flow desde
+tu backend antes de marcar una orden como pagada.
+
+```typescript
+const result = await flow.webhooks.verifyPaymentConfirmation(
+  { token: req.body.token },
+  {
+    expectedCommerceOrder: '123456',
+    expectedAmount: 10000,
+    expectedCurrency: 'CLP',
+  },
+);
+
+if (!result.valid) {
+  // Responde 200 si quieres evitar reintentos de Flow, pero no proceses la orden.
+  return;
+}
+
+// result.payment fue confirmado con Flow y status 2 (Pagada) por defecto.
+```
+
 ## Funcionalidades principales
 
 ### 1. Pagos

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,7 +60,7 @@ Si el reporte está fuera de alcance, te lo indicaremos y, cuando aplique, te or
 
 - Nunca expongas `secretKey` en frontend, repositorios, logs ni variables de entorno del cliente
 - Usa variables de entorno o un gestor de secretos en el servidor
-- Valida en tu backend los callbacks y confirmaciones de pago; no confíes solo en datos del cliente
+- Valida en tu backend los callbacks y confirmaciones de pago con `flow.webhooks.verifyPaymentConfirmation`; no confíes solo en el `token` recibido
 - Mantén actualizadas las dependencias y la versión del paquete
 - Usa `sandbox` para pruebas y separa credenciales de producción
 - Revisa periódicamente [Dependabot](https://github.com/nicotordev/flowcl-pagos/security/dependabot) y actualiza cuando publiquemos parches

--- a/src/__tests__/flow.unit.test.ts
+++ b/src/__tests__/flow.unit.test.ts
@@ -1,7 +1,13 @@
 import Flow from '../clients/flow';
 import FlowMerchants from '../clients/flow.merchants';
 import FlowPayments from '../clients/flow.payments';
-import { FlowAuthenticationError, createFlowAPIError } from '../errors';
+import FlowWebhooks from '../clients/flow.webhooks';
+import {
+  FlowAPIError,
+  FlowAuthenticationError,
+  createFlowAPIError,
+} from '../errors';
+import { FlowPaymentStatusResponse } from '../types/flow.payments';
 import {
   generateFormData,
   generateSignature,
@@ -10,6 +16,18 @@ import {
 import { flowIntegrationConfig } from '../test-utils/flowIntegration';
 
 describe('Flow SDK (unit)', () => {
+  const paidPayment: FlowPaymentStatusResponse = {
+    flowOrder: 123,
+    commerceOrder: 'order-123',
+    requestDate: '2026-06-14 10:00:00',
+    status: 2,
+    statusStr: 'Pagada',
+    subject: 'Orden de prueba',
+    currency: 'CLP',
+    amount: 1000,
+    payer: 'cliente@example.com',
+  };
+
   it('lanza FlowAuthenticationError sin apiKey o secretKey', () => {
     expect(
       () => new Flow('', flowIntegrationConfig.secretKey, 'sandbox'),
@@ -204,5 +222,73 @@ describe('Flow SDK (unit)', () => {
     );
 
     consoleError.mockRestore();
+  });
+
+  it('verifica callbacks de pago consultando el token contra Flow', async () => {
+    const byToken = jest.fn().mockResolvedValue(paidPayment);
+    const webhooks = new FlowWebhooks({
+      status: { byToken },
+    } as unknown as FlowPayments);
+
+    const result = await webhooks.verifyPaymentConfirmation(
+      { token: 'callback-token' },
+      {
+        expectedCommerceOrder: 'order-123',
+        expectedAmount: 1000,
+        expectedCurrency: 'CLP',
+      },
+    );
+
+    expect(result.valid).toBe(true);
+    expect(byToken).toHaveBeenCalledWith('callback-token');
+    if (result.valid) {
+      expect(result.payment).toBe(paidPayment);
+    }
+  });
+
+  it('rechaza callbacks sin token', async () => {
+    const byToken = jest.fn();
+    const webhooks = new FlowWebhooks({
+      status: { byToken },
+    } as unknown as FlowPayments);
+
+    await expect(webhooks.verifyPaymentConfirmation({})).resolves.toEqual({
+      valid: false,
+      reason: 'missing_token',
+    });
+    expect(byToken).not.toHaveBeenCalled();
+  });
+
+  it('rechaza tokens que Flow no reconoce', async () => {
+    const flowError = new FlowAPIError(400, 'invalid token');
+    const webhooks = new FlowWebhooks({
+      status: {
+        byToken: jest.fn().mockRejectedValue(flowError),
+      },
+    } as unknown as FlowPayments);
+
+    await expect(
+      webhooks.verifyPaymentConfirmation({ token: 'fake-token' }),
+    ).resolves.toEqual({
+      valid: false,
+      reason: 'flow_api_error',
+      error: flowError,
+    });
+  });
+
+  it('rechaza tokens validos que no coinciden con la orden esperada', async () => {
+    const webhooks = new FlowWebhooks({
+      status: { byToken: jest.fn().mockResolvedValue(paidPayment) },
+    } as unknown as FlowPayments);
+
+    await expect(
+      webhooks.verifyPaymentConfirmation('callback-token', {
+        expectedCommerceOrder: 'otra-orden',
+      }),
+    ).resolves.toEqual({
+      valid: false,
+      reason: 'commerce_order_mismatch',
+      payment: paidPayment,
+    });
   });
 });

--- a/src/clients/flow.ts
+++ b/src/clients/flow.ts
@@ -9,6 +9,7 @@ import FlowRefunds from './flow.refunds';
 import FlowSettlements from './flow.settlement';
 import FlowSubscriptions from './flow.subscriptions';
 import FlowSubscriptionsItems from './flow.subscriptionsItems';
+import FlowWebhooks from './flow.webhooks';
 /**
  * Cliente para interactuar con la API de Flow.
  */
@@ -55,6 +56,10 @@ class Flow {
    * Objecto que proporciona metodos para interactuar con los merchants en Flow.
    */
   public merchants: FlowMerchants;
+  /**
+   * Helpers para verificar callbacks entrantes de Flow.
+   */
+  public webhooks: FlowWebhooks;
 
   /**
    * Constructor de la clase FlowClient.
@@ -99,6 +104,7 @@ class Flow {
     this.invoices = new FlowInvoices(apiKey, secretKey, baseURL, options);
     this.settlements = new FlowSettlements(apiKey, secretKey, baseURL, options);
     this.merchants = new FlowMerchants(apiKey, secretKey, baseURL, options);
+    this.webhooks = new FlowWebhooks(this.payments);
   }
 }
 

--- a/src/clients/flow.webhooks.ts
+++ b/src/clients/flow.webhooks.ts
@@ -14,7 +14,7 @@ type FlowPaymentStatusClient = Pick<FlowPayments, 'status'>;
  */
 export default class FlowWebhooks {
   /**
-   * Verifica un callback de confirmacion de pago consultando el token contra Flow.
+   * Verifica un callback de confirmación de pago consultando el token contra Flow.
    */
   public paymentConfirmation = this.verifyPaymentConfirmation.bind(this);
   public verifyCallback = this.verifyPaymentConfirmation.bind(this);
@@ -23,7 +23,7 @@ export default class FlowWebhooks {
   constructor(private payments: FlowPaymentStatusClient) {}
 
   /**
-   * Flow envia a urlConfirmation solo un token por POST. Este helper no confia
+   * Flow envía a urlConfirmation solo un token por POST. Este helper no confía
    * en el callback: consulta payment/getStatus con las credenciales del SDK y
    * valida el estado y, opcionalmente, los datos esperados de la orden local.
    */

--- a/src/clients/flow.webhooks.ts
+++ b/src/clients/flow.webhooks.ts
@@ -1,0 +1,93 @@
+import { FlowAPIError } from '../errors';
+import { FlowPaymentStatusResponse } from '../types/flow.payments';
+import {
+  FlowPaymentConfirmationPayload,
+  FlowVerifyPaymentConfirmationOptions,
+  FlowVerifyPaymentConfirmationResult,
+} from '../types/flow.webhooks';
+import FlowPayments from './flow.payments';
+
+type FlowPaymentStatusClient = Pick<FlowPayments, 'status'>;
+
+/**
+ * Helpers para verificar callbacks entrantes de Flow.
+ */
+export default class FlowWebhooks {
+  /**
+   * Verifica un callback de confirmacion de pago consultando el token contra Flow.
+   */
+  public paymentConfirmation = this.verifyPaymentConfirmation.bind(this);
+  public verifyCallback = this.verifyPaymentConfirmation.bind(this);
+  public verifyWebhook = this.verifyPaymentConfirmation.bind(this);
+
+  constructor(private payments: FlowPaymentStatusClient) {}
+
+  /**
+   * Flow envia a urlConfirmation solo un token por POST. Este helper no confia
+   * en el callback: consulta payment/getStatus con las credenciales del SDK y
+   * valida el estado y, opcionalmente, los datos esperados de la orden local.
+   */
+  public async verifyPaymentConfirmation(
+    payload: string | FlowPaymentConfirmationPayload,
+    options: FlowVerifyPaymentConfirmationOptions = {},
+  ): Promise<FlowVerifyPaymentConfirmationResult> {
+    const token = this.getToken(payload);
+
+    if (!token) {
+      return { valid: false, reason: 'missing_token' };
+    }
+
+    let payment: FlowPaymentStatusResponse;
+
+    try {
+      payment = await this.payments.status.byToken(token);
+    } catch (error) {
+      if (error instanceof FlowAPIError) {
+        return { valid: false, reason: 'flow_api_error', error };
+      }
+
+      throw error;
+    }
+
+    const expectedStatus = options.expectedStatus ?? 2;
+
+    if (payment.status !== expectedStatus) {
+      return { valid: false, reason: 'status_mismatch', payment };
+    }
+
+    if (
+      options.expectedCommerceOrder !== undefined &&
+      payment.commerceOrder !== options.expectedCommerceOrder
+    ) {
+      return { valid: false, reason: 'commerce_order_mismatch', payment };
+    }
+
+    if (
+      options.expectedAmount !== undefined &&
+      payment.amount !== options.expectedAmount
+    ) {
+      return { valid: false, reason: 'amount_mismatch', payment };
+    }
+
+    if (
+      options.expectedCurrency !== undefined &&
+      payment.currency !== options.expectedCurrency
+    ) {
+      return { valid: false, reason: 'currency_mismatch', payment };
+    }
+
+    return { valid: true, payment };
+  }
+
+  private getToken(payload: string | FlowPaymentConfirmationPayload): string {
+    if (typeof payload === 'string') {
+      return payload.trim();
+    }
+
+    if (payload.token === undefined || payload.token === null) {
+      return '';
+    }
+
+    return String(payload.token).trim();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,14 @@
 // src/index.ts
 export { default as Flow } from './clients/flow';
+export { default as FlowWebhooks } from './clients/flow.webhooks';
 export type {
   FlowAPIErrorLogEvent,
   FlowClientOptions,
   FlowLogger,
 } from './errors';
+export type {
+  FlowPaymentConfirmationPayload,
+  FlowVerifyPaymentConfirmationOptions,
+  FlowVerifyPaymentConfirmationResult,
+  FlowWebhookVerificationFailureReason,
+} from './types/flow.webhooks';

--- a/src/types/flow.webhooks.ts
+++ b/src/types/flow.webhooks.ts
@@ -15,19 +15,19 @@ type FlowWebhookVerificationFailureReason =
 
 type FlowVerifyPaymentConfirmationOptions = {
   /**
-   * Estado requerido para considerar valido el callback. Por defecto exige pago exitoso: 2 (Pagada).
+   * Estado requerido para considerar válido el callback. Por defecto exige pago exitoso: 2 (Pagada).
    */
   expectedStatus?: FlowPaymentStatusResponse['status'];
   /**
-   * Orden local esperada. Evita aceptar tokens validos de otra orden.
+   * Orden local esperada. Evita aceptar tokens válidos de otra orden.
    */
   expectedCommerceOrder?: string;
   /**
-   * Monto local esperado. Evita aceptar tokens validos con otro monto.
+   * Monto local esperado. Evita aceptar tokens válidos con otro monto.
    */
   expectedAmount?: number;
   /**
-   * Moneda local esperada. Evita aceptar tokens validos con otra moneda.
+   * Moneda local esperada. Evita aceptar tokens válidos con otra moneda.
    */
   expectedCurrency?: string;
 };

--- a/src/types/flow.webhooks.ts
+++ b/src/types/flow.webhooks.ts
@@ -1,0 +1,52 @@
+import { FlowAPIError } from '../errors';
+import { FlowPaymentStatusResponse } from './flow.payments';
+
+type FlowPaymentConfirmationPayload = {
+  token?: string | number | null;
+};
+
+type FlowWebhookVerificationFailureReason =
+  | 'missing_token'
+  | 'flow_api_error'
+  | 'status_mismatch'
+  | 'commerce_order_mismatch'
+  | 'amount_mismatch'
+  | 'currency_mismatch';
+
+type FlowVerifyPaymentConfirmationOptions = {
+  /**
+   * Estado requerido para considerar valido el callback. Por defecto exige pago exitoso: 2 (Pagada).
+   */
+  expectedStatus?: FlowPaymentStatusResponse['status'];
+  /**
+   * Orden local esperada. Evita aceptar tokens validos de otra orden.
+   */
+  expectedCommerceOrder?: string;
+  /**
+   * Monto local esperado. Evita aceptar tokens validos con otro monto.
+   */
+  expectedAmount?: number;
+  /**
+   * Moneda local esperada. Evita aceptar tokens validos con otra moneda.
+   */
+  expectedCurrency?: string;
+};
+
+type FlowVerifyPaymentConfirmationResult =
+  | {
+      valid: true;
+      payment: FlowPaymentStatusResponse;
+    }
+  | {
+      valid: false;
+      reason: FlowWebhookVerificationFailureReason;
+      payment?: FlowPaymentStatusResponse;
+      error?: FlowAPIError;
+    };
+
+export type {
+  FlowPaymentConfirmationPayload,
+  FlowVerifyPaymentConfirmationOptions,
+  FlowVerifyPaymentConfirmationResult,
+  FlowWebhookVerificationFailureReason,
+};


### PR DESCRIPTION
## What changed

- Adds `FlowWebhooks` and exposes it as `flow.webhooks`.
- Adds `verifyPaymentConfirmation(...)` plus aliases `verifyWebhook`, `verifyCallback`, and `paymentConfirmation`.
- Verifies Flow `urlConfirmation` callbacks by using the callback `token` to query `payment/getStatus` through the existing signed SDK client.
- Requires paid status (`status: 2`) by default and supports optional checks for `commerceOrder`, `amount`, and `currency`.
- Exports webhook verification types from the package entrypoint.
- Documents safe callback handling in `README.md` and updates `SECURITY.md`.
- Adds unit tests for valid callbacks, missing token, Flow API rejection, and local order mismatch.

## Why

Flow confirmation callbacks provide a POST body containing a transaction token. Consumers should not mark orders as paid from the callback body alone. This helper gives SDK users a first-class backend verification path to avoid accepting forged or mismatched payment notifications.

## Validation

- `npm run build`
- `npm run test:unit`
- `npm run lint` (passes with existing test `console` warnings)